### PR TITLE
Fixed parsing in get_candle with context for Pocket Option API changes

### DIFF
--- a/crates/binary_options_tools/src/pocketoption/parser/message.rs
+++ b/crates/binary_options_tools/src/pocketoption/parser/message.rs
@@ -101,6 +101,9 @@ impl WebSocketMessage {
                 if let Ok(stream) = from_str::<UpdateStream>(&data) {
                     return Self::UpdateStream(stream);
                 }
+                if let Ok(stream) = from_str::<LoadHistoryPeriodResult>(&data) {
+                    return Self::LoadHistoryPeriod(stream);
+                }
             }
             MessageInfo::UpdateHistoryNew => {
                 if let Ok(history) = from_str::<UpdateHistoryNewFast>(&data) {


### PR DESCRIPTION
The get_candle function was failing due to a 16s timeout. The receiver was waiting for a LoadHistoryPeriod stream, which should have been matched by MessageInfo::LoadHistoryPeriod. However, in the updated Pocket Option WebSocket API, the response format changed and was instead caught as MessageInfo::UpdateStream.



Updated the parsing logic to handle this case by attempting to deserialize LoadHistoryPeriodResult under UpdateStream:

```
MessageInfo::UpdateStream => {
    if let Ok(stream) = from_str::<UpdateStream>(&data) {
        return Self::UpdateStream(stream);
    }
    if let Ok(stream) = from_str::<LoadHistoryPeriodResult>(&data) {
        return Self::LoadHistoryPeriod(stream);
    }
}
```
This ensures compatibility with the new API response structure and prevents the timeout issue.

Fixes: https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/issues/17