### PR TITLE
fix: remove hardcoded 60s timeout in check_win

### DIFF
--- a/BinaryOptionsToolsV2/python/BinaryOptionsToolsV2/pocketoption/asynchronous.py
+++ b/BinaryOptionsToolsV2/python/BinaryOptionsToolsV2/pocketoption/asynchronous.py
@@ -332,10 +332,7 @@ class PocketOptionAsync:
             TimeoutError: If result check times out
         """
 
-        # Let Rust handle the timeout — it knows the trade close timestamp.
-        # The previous hardcoded 60s timeout broke trades of any duration
-        # because asyncio cancelled the coroutine right when the server
-        # was sending the result.
+        # Let Rust handle the timeout based on the trade close timestamp.
         return await self._get_trade_result(id)
 
     async def get_deal_end_time(self, trade_id: str) -> Optional[int]:

--- a/BinaryOptionsToolsV2/python/BinaryOptionsToolsV2/pocketoption/asynchronous.py
+++ b/BinaryOptionsToolsV2/python/BinaryOptionsToolsV2/pocketoption/asynchronous.py
@@ -332,15 +332,11 @@ class PocketOptionAsync:
             TimeoutError: If result check times out
         """
 
-        # Set a reasonable timeout to prevent hanging
-        timeout_seconds = 60  # Increased timeout to accommodate longer trade durations
-
-        try:
-            # Use asyncio.wait_for as additional protection against hanging
-            trade = await asyncio.wait_for(self._get_trade_result(id), timeout=timeout_seconds)
-            return trade
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"Timeout waiting for trade result for ID: {id}")
+        # Let Rust handle the timeout — it knows the trade close timestamp.
+        # The previous hardcoded 60s timeout broke trades of any duration
+        # because asyncio cancelled the coroutine right when the server
+        # was sending the result.
+        return await self._get_trade_result(id)
 
     async def get_deal_end_time(self, trade_id: str) -> Optional[int]:
         """


### PR DESCRIPTION
The asyncio.wait_for wrapper with timeout_seconds=60 was cancelling the coroutine exactly when trades closed, causing CancelledError -> TimeoutError on all trade durations (30s, 60s, 120s+).

Rust already handles the timeout internally via the trade close timestamp, so the Python wrapper is unnecessary and harmful.

Tested on Windows with 30s, 60s and 120s trades - all return correct results with no errors.

# Pull Request

## Overview

Summarize the changes and the motivation behind them. Link any related issues using keywords (e.g., Fixes #123).

## Changes

- List key changes here.
- Keep descriptions concise and technical.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / Examples
- [ ] Performance / Refactoring
- [ ] CI/CD / Build System

## Validation

Describe how the changes were tested.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual verification

### Environment

- OS:
- Python Version:
- Rust Version:

## Checklist

- [ ] Code follows project conventions and style guidelines.
- [ ] Documentation and examples updated if necessary.
- [ ] All tests pass locally.
- [ ] No new warnings introduced.

## Screenshots (Optional)

Add relevant visuals if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trade result checks no longer enforce a 60-second timeout; the system will wait until a trade outcome is available rather than raising a timeout error.
  * Removed timeout-specific error messaging for trade checks, reducing premature timeout failures and improving reliability for longer-running trades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->