### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete URL substring sanitization

### DIFF
--- a/tests/python/pocketoption/test_sync_mocked.py
+++ b/tests/python/pocketoption/test_sync_mocked.py
@@ -4,6 +4,7 @@ import threading
 import types
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
 
 import pytest
 
@@ -529,7 +530,10 @@ class TestPocketOptionInit:
     def test_init_with_custom_url(self, mock_pocketoption_async):
         """Test that custom URL is added to config."""
         client = PocketOption("test_ssid", url="wss://custom.com")
-        assert "wss://custom.com" in client.config.urls
+        assert any(
+            (parsed.scheme, parsed.hostname) == ("wss", "custom.com")
+            for parsed in (urlparse(url) for url in client.config.urls)
+        )
         client.shutdown()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/security/code-scanning/20](https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/security/code-scanning/20)

To fix this, avoid raw string containment for URL validation assertions. Parse the configured URLs and assert that one URL has the exact expected scheme and host.

Best single fix in `tests/python/pocketoption/test_sync_mocked.py`:
- Add `urlparse` import from `urllib.parse`.
- In `test_init_with_custom_url`, replace the direct containment assertion with a parsed-host/scheme assertion over `client.config.urls`.

This preserves functionality (verifying custom URL was added) while making the check structurally safe and explicit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced custom URL initialization test to be more resilient by validating normalized URL components instead of exact raw URL strings, reducing sensitivity to formatting variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->