### PR TITLE
fix: support numeric requestId in deal

### DIFF
--- a/crates/binary_options_tools/src/framework/virtual_market.rs
+++ b/crates/binary_options_tools/src/framework/virtual_market.rs
@@ -1,6 +1,6 @@
 use crate::framework::market::Market;
 use crate::pocketoption::error::PocketResult;
-use crate::pocketoption::types::Deal;
+use crate::pocketoption::types::{Deal, RequestId};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -115,7 +115,7 @@ impl Market for VirtualMarket {
             percent_loss: 100,
             command: 0, // Call
             uid: 0,
-            request_id: Some(id),
+            request_id: Some(RequestId::Uuid(id)),
             open_time: entry_time.to_rfc3339(),
             close_time: (entry_time + chrono::Duration::seconds(time as i64)).to_rfc3339(),
             refund_time: None,
@@ -192,7 +192,7 @@ impl Market for VirtualMarket {
             percent_loss: 100,
             command: 1, // Put
             uid: 0,
-            request_id: Some(id),
+            request_id: Some(RequestId::Uuid(id)),
             open_time: entry_time.to_rfc3339(),
             close_time: (entry_time + chrono::Duration::seconds(time as i64)).to_rfc3339(),
             refund_time: None,
@@ -264,7 +264,7 @@ impl Market for VirtualMarket {
                     Action::Put => 1,
                 },
                 uid: 0,
-                request_id: Some(trade.id),
+                request_id: Some(RequestId::Uuid(trade.id)),
                 open_time: entry_timestamp.to_rfc3339(),
                 close_time: close_timestamp.to_rfc3339(),
                 refund_time: None,
@@ -339,7 +339,7 @@ impl Market for VirtualMarket {
                 Action::Put => 1,
             },
             uid: 0,
-            request_id: Some(trade.id),
+            request_id: Some(RequestId::Uuid(trade.id)),
             open_time: entry_timestamp.to_rfc3339(),
             close_time: close_timestamp.to_rfc3339(),
             refund_time: None,

--- a/crates/binary_options_tools/src/pocketoption/modules/trades.rs
+++ b/crates/binary_options_tools/src/pocketoption/modules/trades.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use crate::pocketoption::{
     error::{PocketError, PocketResult},
     state::State,
-    types::{Action, Deal, FailOpenOrder, MultiPatternRule, OpenOrder},
+    types::{Action, Deal, FailOpenOrder, MultiPatternRule, OpenOrder, RequestId},
 };
 
 /// Command enum for the `TradesApiModule`.
@@ -254,7 +254,10 @@ impl ApiModule<State> for TradesApiModule {
                               self.state.trade_state.add_opened_deal(*deal.clone()).await;
                               info!(target: "TradesApiModule", "Trade opened: {}", deal.id);
 
-                              let req_id = deal.request_id.unwrap_or_default();
+                              let req_id = match deal.request_id.as_ref() {
+                                  Some(RequestId::Uuid(id)) => *id,
+                                  Some(RequestId::Number(_)) | None => Uuid::nil(),
+                              };
 
                               // Clean up pending_market_orders in state
                               self.state.trade_state.pending_market_orders.write().await.remove(&req_id);

--- a/crates/binary_options_tools/src/pocketoption/modules/trades_tests/common.rs
+++ b/crates/binary_options_tools/src/pocketoption/modules/trades_tests/common.rs
@@ -14,7 +14,7 @@ use crate::pocketoption::{
     error::{PocketError, PocketResult},
     ssid::{Real, SessionData, Ssid as PocketSsid},
     state::{State, StateBuilder, TradeState},
-    types::{Action, Deal, FailOpenOrder, OpenOrder},
+    types::{Action, Deal, FailOpenOrder, OpenOrder, RequestId},
 };
 
 use crate::pocketoption::modules::trades::{
@@ -60,7 +60,7 @@ pub fn create_test_deal(req_id: Uuid, asset: &str) -> Deal {
         refund_time: None,
         refund_timestamp: None,
         uid: 123456789,
-        request_id: Some(req_id),
+        request_id: Some(RequestId::Uuid(req_id)),
         amount: Decimal::from(10),
         profit: Decimal::from(5),
         percent_profit: 50,

--- a/crates/binary_options_tools/src/pocketoption/types.rs
+++ b/crates/binary_options_tools/src/pocketoption/types.rs
@@ -535,6 +535,22 @@ pub struct FailOpenOrder {
     pub asset: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum RequestId {
+    Uuid(Uuid),
+    Number(u64),
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RequestId::Uuid(id) => write!(f, "{id}"),
+            RequestId::Number(id) => write!(f, "{id}"),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct OpenOrder {
@@ -561,7 +577,8 @@ pub struct Deal {
     pub refund_time: Option<Value>,
     pub refund_timestamp: Option<Value>,
     pub uid: u64,
-    pub request_id: Option<Uuid>,
+    #[serde(default)]
+    pub request_id: Option<RequestId>,
     pub amount: Decimal,
     pub profit: Decimal,
     pub percent_profit: i32,


### PR DESCRIPTION
# Pull Request

## Overview

Fixes PocketOption REAL account deal parsing when `requestId` is returned as a number instead of a expected UUID.

REAL account websocket returns `requestId` as a numeral, while DEMO doesn't pass it at all. Previously `Deal.request_id` expected only `Uuid`, which could make deserialization fail.

## Changes

added a `RequestId` enum that supports both UUID and numeric `requestId` values.
updated `Deal.request_id` to use `Option<RequestId>`.
updated related modules expecting uuid from requestId
also changed the trade test so `cargo test` wouldn't scream at me, would probably compile without it

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / Examples
- [ ] Performance / Refactoring
- [ ] CI/CD / Build System

## Validation

Describe how the changes were tested.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual verification

### Environment

- OS: Windows 11
- Python Version: 3.14
- Rust Version: 1.91.1

## Checklist

- [ ] Code follows project conventions and style guidelines.
- [ ] Documentation and examples updated if necessary.
- [ ] All tests pass locally.
- [ ] No new warnings introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced request identifier support to accommodate both UUID and numeric formats in trade tracking.

* **Bug Fixes**
  * Improved handling of missing or non-standard request identifiers to use consistent fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChipaDevTeam/BinaryOptionsTools-v2/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->