### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete URL substring sanitization

### DIFF
--- a/docs/tutorials/scripts/SSID_Fetcher_UserScript.user.js
+++ b/docs/tutorials/scripts/SSID_Fetcher_UserScript.user.js
@@ -54,10 +54,15 @@
     const result = originalSend.apply(this, arguments);
 
     // Get the URL from the native property or our fallback tag
-    const socketUrl = (this.url || this._interceptUrl || "").toLowerCase();
+    const rawSocketUrl = this.url || this._interceptUrl || "";
+    const socketUrl = rawSocketUrl.toLowerCase();
 
-    // STRICT EXCLUSION: If the URL belongs to events-po.com, bypass the logic immediately
-    if (socketUrl.includes("events-po.com")) {
+    // STRICT EXCLUSION: If the URL host is events-po.com or one of its subdomains, bypass immediately
+    let socketHost = "";
+    try {
+      socketHost = new URL(rawSocketUrl, window.location.href).hostname.toLowerCase();
+    } catch (e) {}
+    if (socketHost === "events-po.com" || socketHost.endsWith(".events-po.com")) {
       return result;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/security/code-scanning/22](https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/security/code-scanning/22)

Use the built-in `URL` parser to extract `hostname` from `this.url` / fallback URL, then compare hostnames safely.

Best fix in this file:
- In `docs/tutorials/scripts/SSID_Fetcher_UserScript.user.js`, replace the `socketUrl.includes("events-po.com")` check with:
  - Parse `rawSocketUrl` via `new URL(rawSocketUrl, window.location.href)` (base handles relative/fallback robustness).
  - Normalize hostname to lowercase.
  - Exclude only when hostname is exactly `events-po.com` or a subdomain ending with `.events-po.com`.
- Keep existing behavior otherwise (still show URL in confirm, still send immediately, still bypass only intended hosts).
- No new dependencies/imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain verification logic for WebSocket communication to more accurately identify and properly bypass target domains, reducing false positives and ensuring correct request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->