### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete URL substring sanitization

### DIFF
--- a/tests/python/pocketoption/test_async_mocked.py
+++ b/tests/python/pocketoption/test_async_mocked.py
@@ -4,6 +4,7 @@ import sys
 import types
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
 
 import pytest
 
@@ -425,7 +426,10 @@ class TestPocketOptionAsyncInit:
     async def test_init_with_custom_url(self, mock_raw_pocketoption):
         """Test that custom URL is added to config."""
         client = PocketOptionAsync("test_ssid", url="wss://custom.com")
-        assert "wss://custom.com" in client.config.urls
+        assert any(
+            parsed.scheme == "wss" and parsed.hostname == "custom.com"
+            for parsed in (urlparse(url) for url in client.config.urls)
+        )
         await client.shutdown()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/security/code-scanning/23](https://github.com/ChipaDevTeam/BinaryOptionsTools-v2/security/code-scanning/23)

To fix this, avoid direct string containment assertions for URL trust checks. Parse URLs and compare structured components (especially hostname), or compare exact canonical URL values.

Best fix in this file: update `test_init_with_custom_url` to parse each configured URL via `urllib.parse.urlparse` and assert that at least one parsed hostname exactly equals `custom.com` (and optionally scheme is `wss`). This removes ambiguous substring-based validation and aligns with robust URL validation practices.

Changes needed in `tests/python/pocketoption/test_async_mocked.py`:
- Add import: `from urllib.parse import urlparse`
- Replace line 428 assertion with a parsed URL host/scheme check using `any(...)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation logic for custom WebSocket URL configuration in test suite, ensuring proper URL parsing and validation of connection endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->