### PR TITLE
Add resilient parsing tests for BalanceModule and DealsApiModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,48 +229,53 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
- ### Real-time Data Streaming
- 
- #### Ticks Stream
- ```python
- async with PocketOptionAsync(ssid="...") as client:
-     async for candle in await client.subscribe_symbol("EURUSD_otc"):
-         print(f"Price: {candle['close']}")
- ```
- 
- #### Live Candle Stream (Recommended)
- To fetch historical backfill and stream gap-free live candles in real-time, use `get_candles_live()`. This method is available in both async and sync clients. It buffers incoming ticks, merges historical data, and yields updated candles (both closed candles and the forming candle).
- 
- **Async Example:**
- ```python
- from BinaryOptionsToolsV2 import PocketOptionAsync
- 
- async def main():
-     async with PocketOptionAsync(ssid="...") as client:
-         # Stream live candles (yields a tuple: closed_candles list, current_forming_candle dict)
-         async for closed, forming in client.get_candles_live("EURUSD_otc", period=60, hours=2.0, max_rows=100):
-             print(f"Closed candles count: {len(closed)}")
-             if forming:
-                 print(f"Forming Candle Close Price: {forming['close']}")
- ```
- 
- **Sync Example:**
- ```python
- from BinaryOptionsToolsV2 import PocketOption
- 
- client = PocketOption(ssid="...")
- # Iterate over live candles
- for closed, forming in client.get_candles_live("EURUSD_otc", period=60, hours=2.0, max_rows=100):
-     print(f"Closed candles count: {len(closed)}")
-     if forming:
-         print(f"Forming Candle Close Price: {forming['close']}")
- ```
- 
- ### Deprecated Candle Methods
- 
- The duplicate candle functions `candles()` and `get_candles()` are **deprecated** and will be removed in a future release. 
- * **Reason**: They only fetch closed historical candles, can introduce gaps when called sequentially during live trading, and do not include the currently forming candle.
- * **Compatibility**: To preserve backward compatibility, these methods have been redirected to run `get_candles_live()` internally under the hood (returning the first yielded list of closed candles). However, it is highly recommended to migrate to `get_candles_live()`.
+
+### Real-time Data Streaming
+
+#### Ticks Stream
+
+```python
+async with PocketOptionAsync(ssid="...") as client:
+    async for candle in await client.subscribe_symbol("EURUSD_otc"):
+        print(f"Price: {candle['close']}")
+```
+
+#### Live Candle Stream (Recommended)
+
+To fetch historical backfill and stream gap-free live candles in real-time, use `get_candles_live()`. This method is available in both async and sync clients. It buffers incoming ticks, merges historical data, and yields updated candles (both closed candles and the forming candle).
+
+**Async Example:**
+
+```python
+from BinaryOptionsToolsV2 import PocketOptionAsync
+
+async def main():
+    async with PocketOptionAsync(ssid="...") as client:
+        # Stream live candles (yields a tuple: closed_candles list, current_forming_candle dict)
+        async for closed, forming in client.get_candles_live("EURUSD_otc", period=60, hours=2.0, max_rows=100):
+            print(f"Closed candles count: {len(closed)}")
+            if forming:
+                print(f"Forming Candle Close Price: {forming['close']}")
+```
+
+**Sync Example:**
+
+```python
+from BinaryOptionsToolsV2 import PocketOption
+
+client = PocketOption(ssid="...")
+# Iterate over live candles
+for closed, forming in client.get_candles_live("EURUSD_otc", period=60, hours=2.0, max_rows=100):
+    print(f"Closed candles count: {len(closed)}")
+    if forming:
+        print(f"Forming Candle Close Price: {forming['close']}")
+```
+
+### Deprecated Candle Methods
+
+The duplicate candle functions `candles()` and `get_candles()` are **deprecated** and will be removed in a future release. 
+* **Reason**: They only fetch closed historical candles, can introduce gaps when called sequentially during live trading, and do not include the currently forming candle.
+* **Compatibility**: To preserve backward compatibility, these methods have been redirected to run `get_candles_live()` internally under the hood (returning the first yielded list of closed candles). However, it is highly recommended to migrate to `get_candles_live()`.
 
 ---
 

--- a/crates/binary_options_tools/src/pocketoption/modules/mod.rs
+++ b/crates/binary_options_tools/src/pocketoption/modules/mod.rs
@@ -49,15 +49,3 @@ pub mod raw;
 pub mod server_time;
 pub mod subscriptions;
 pub mod trades;
-
-#[cfg(test)]
-mod deals_tests;
-
-#[cfg(test)]
-mod pending_trades_tests;
-
-#[cfg(test)]
-mod resilient_parsing_tests;
-
-#[cfg(test)]
-mod trades_tests;

--- a/crates/binary_options_tools/src/pocketoption/modules/trades_tests/mod.rs
+++ b/crates/binary_options_tools/src/pocketoption/modules/trades_tests/mod.rs
@@ -1,2 +1,0 @@
-pub mod common;
-pub mod concurrency;

--- a/crates/binary_options_tools/tests/common/mod.rs
+++ b/crates/binary_options_tools/tests/common/mod.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports, dead_code, unused_variables)]
 use binary_options_tools_core::{
     reimports::{AsyncReceiver, AsyncSender, Message},
     traits::{ApiModule, RunnerCommand},
@@ -9,14 +8,14 @@ use std::sync::Arc;
 use tokio::time::timeout;
 use uuid::Uuid;
 
-use crate::pocketoption::{
+use binary_options_tools::pocketoption::{
     error::{PocketError, PocketResult},
     ssid::{Real, SessionData, Ssid as PocketSsid},
     state::{State, StateBuilder, TradeState},
     types::{Action, Deal, FailOpenOrder, OpenOrder, RequestId},
 };
 
-use crate::pocketoption::modules::trades::{
+use binary_options_tools::pocketoption::modules::trades::{
     Command, CommandResponse, TradesApiModule, TradesHandle,
 };
 

--- a/crates/binary_options_tools/tests/concurrency.rs
+++ b/crates/binary_options_tools/tests/concurrency.rs
@@ -1,11 +1,34 @@
-use super::common::*;
-use crate::pocketoption::types::Action;
+use binary_options_tools::pocketoption::types::Action;
 use binary_options_tools_core::reimports::Message;
 use rust_decimal_macros::dec;
 use std::sync::Arc;
 use tokio::time::{timeout, Duration};
 use uuid::Uuid;
 
+use binary_options_tools::pocketoption::modules::trades::{
+    Command, CommandResponse, TradesApiModule, TradesHandle,
+};
+use binary_options_tools::pocketoption::{
+    error::{PocketError, PocketResult},
+    ssid::{Real, SessionData, Ssid as PocketSsid},
+    state::{State, StateBuilder, TradeState},
+    types::{Deal, FailOpenOrder, OpenOrder, RequestId},
+};
+use binary_options_tools_core::{
+    reimports::{AsyncReceiver, AsyncSender},
+    traits::{ApiModule, RunnerCommand},
+};
+use kanal::bounded_async;
+use chrono::Utc;
+use rust_decimal::Decimal;
+
+mod common {
+    include!("common/mod.rs");
+}
+
+use common::{
+    create_mock_state, create_test_deal, create_test_fail, create_test_setup, TestSetup,
+};
 #[tokio::test]
 async fn test_concurrent_identical_trades_hammer() {
     let setup = create_test_setup().await;

--- a/crates/binary_options_tools/tests/deals_tests.rs
+++ b/crates/binary_options_tools/tests/deals_tests.rs
@@ -1,21 +1,19 @@
 #[cfg(test)]
 mod tests {
-    use crate::pocketoption::{
-        modules::deals::{Command, CommandResponse, DealsApiModule},
-        state::TradeState,
-        types::Deal,
-    };
-    use binary_options_tools_core::{
-        reimports::Message,
-        traits::{ApiModule, RunnerCommand},
-    };
-    use kanal::bounded_async;
-    use serde_json::json;
-    use std::sync::Arc;
-    use tokio::sync::oneshot;
-    use uuid::Uuid;
-
-    // Helper to create a mock deal
+use binary_options_tools::pocketoption::{
+    modules::deals::{Command, CommandResponse, DealsApiModule},
+    state::TradeState,
+    types::Deal,
+};
+use binary_options_tools_core::{
+    reimports::Message,
+    traits::{ApiModule, RunnerCommand},
+};
+use kanal::bounded_async;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use uuid::Uuid;
     fn create_mock_deal(id: Uuid) -> Deal {
         let json = json!({
             "id": id,
@@ -50,9 +48,9 @@ mod tests {
         trade_state.update_closed_deals(vec![deal.clone()]).await;
 
         let state = Arc::new(
-            crate::pocketoption::state::StateBuilder::default()
+            binary_options_tools::pocketoption::state::StateBuilder::default()
                 .ssid(
-                    crate::pocketoption::ssid::Ssid::parse(
+                    binary_options_tools::pocketoption::ssid::Ssid::parse(
                         "{\"session\":\"test\",\"isDemo\":1,\"uid\":123,\"platform\":2}",
                     )
                     .unwrap(),
@@ -60,7 +58,6 @@ mod tests {
                 .build_with_trade_state(trade_state)
                 .unwrap(),
         );
-
         let (_ws_tx, ws_rx) = bounded_async::<Arc<Message>>(1);
         let (cmd_tx, cmd_rx) = bounded_async::<Command>(1);
         let (res_tx, _res_rx) = bounded_async::<CommandResponse>(1);
@@ -94,9 +91,9 @@ mod tests {
         trade_state.add_opened_deal(deal.clone()).await;
 
         let state = Arc::new(
-            crate::pocketoption::state::StateBuilder::default()
+            binary_options_tools::pocketoption::state::StateBuilder::default()
                 .ssid(
-                    crate::pocketoption::ssid::Ssid::parse(
+                    binary_options_tools::pocketoption::ssid::Ssid::parse(
                         "{\"session\":\"test\",\"isDemo\":1,\"uid\":123,\"platform\":2}",
                     )
                     .unwrap(),

--- a/crates/binary_options_tools/tests/mod.rs
+++ b/crates/binary_options_tools/tests/mod.rs
@@ -1,0 +1,5 @@
+pub mod common;
+pub mod concurrency;
+pub mod deals_tests;
+pub mod pending_trades_tests;
+pub mod resilient_parsing_tests;

--- a/crates/binary_options_tools/tests/pending_trades_tests.rs
+++ b/crates/binary_options_tools/tests/pending_trades_tests.rs
@@ -1,40 +1,36 @@
-#![allow(unused_imports, unused_mut, unused_variables, dead_code)]
-use std::any::Any;
-use std::sync::Arc;
-use std::time::Duration;
-
+#[cfg(test)]
+mod tests {
+use binary_options_tools::pocketoption::{
+    modules::pending_trades::{
+        CancelServerResponse, Command, CommandResponse, PendingTradesApiModule,
+        PendingTradesHandle, ServerResponse,
+    },
+    ssid::{Demo, Ssid},
+    state::State,
+    types::{FailOpenOrder, OpenPendingOrder, PendingOrder, ServerTimeState},
+};
+use binary_options_tools::pocketoption::error::PocketError;
 use binary_options_tools_core::{
-    error::CoreError,
     reimports::{AsyncReceiver, AsyncSender, Message},
-    traits::{ApiModule, Rule, RunnerCommand},
+    traits::{ApiModule, RunnerCommand},
 };
 use kanal::bounded_async;
 use rust_decimal::Decimal;
-use tokio::{
-    sync::Mutex,
-    time::{timeout, Instant},
-};
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::{select, time::timeout};
+use tracing::warn;
 use uuid::Uuid;
-
-use crate::pocketoption::modules::pending_trades::ServerResponse;
-use crate::pocketoption::{
-    error::{PocketError, PocketResult},
-    state::{State, TradeState},
-    types::{FailOpenOrder, MultiPatternRule, OpenPendingOrder, PendingOrder},
-};
-
-use crate::pocketoption::modules::pending_trades::{
-    Command, CommandResponse, PendingTradesApiModule, PendingTradesHandle,
-};
-
-use crate::pocketoption::modules::pending_trades::CancelServerResponse;
-
 // ============== Mock Helpers ==============
 
 /// Creates a minimal mock State with only the fields needed for testing
 fn create_mock_state() -> Arc<State> {
-    use crate::pocketoption::ssid::{Demo, Ssid};
-    use crate::pocketoption::types::ServerTimeState;
+    use binary_options_tools::pocketoption::ssid::{Demo, Ssid};
+    use binary_options_tools::pocketoption::types::ServerTimeState;
+    use binary_options_tools::pocketoption::state::TradeState;
     use std::collections::HashMap;
     // Construct a Demo SSID directly
     let demo_ssid = Ssid::Demo(Demo {
@@ -285,9 +281,8 @@ async fn test_open_pending_order_mismatch_retry() {
 
     let pending_order = create_test_pending_order(Uuid::new_v4());
     let resp_tx_for_module = resp_tx.clone();
-
     let mut module_task = tokio::spawn(async move {
-        use crate::pocketoption::modules::pending_trades::PendingTradesApiModule;
+        use binary_options_tools::pocketoption::modules::pending_trades::PendingTradesApiModule;
         let (msg_tx, msg_rx) = kanal::bounded_async::<Arc<Message>>(1);
         let (ws_tx, mut ws_rx) = kanal::bounded_async(10);
         let (runner_tx, _) = kanal::bounded_async(10);
@@ -1153,6 +1148,5 @@ async fn test_cancel_pending_orders_batch_partial_success() {
     .unwrap();
 
     assert_eq!(received.len(), 1);
-
-    module_task.abort();
+    }
 }

--- a/crates/binary_options_tools/tests/resilient_parsing_tests.rs
+++ b/crates/binary_options_tools/tests/resilient_parsing_tests.rs
@@ -1,14 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use crate::pocketoption::modules::balance::BalanceModule;
-    use crate::pocketoption::modules::deals::DealsApiModule;
-    use crate::pocketoption::ssid::Ssid;
-    use crate::pocketoption::state::StateBuilder;
+    use binary_options_tools::pocketoption::modules::balance::BalanceModule;
+    use binary_options_tools::pocketoption::modules::deals::DealsApiModule;
+    use binary_options_tools::pocketoption::ssid::Ssid;
+    use binary_options_tools::pocketoption::state::StateBuilder;
     use binary_options_tools_core::reimports::{bounded_async, Message};
     use binary_options_tools_core::traits::{ApiModule, LightweightModule};
     use rust_decimal_macros::dec;
     use std::sync::Arc;
-
     #[tokio::test]
     async fn test_balance_module_resilient_parsing() {
         let dummy_ssid = r#"42["auth",{"session":"dummy","isDemo":1,"uid":123,"platform":2}]"#;

--- a/examples/python/async/check_win.py
+++ b/examples/python/async/check_win.py
@@ -15,7 +15,7 @@ async def main(ssid: str):
         asset="EURUSD_otc", amount=1.0, time=300, check_win=False
     )
     print(buy_id, sell_id)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     buy_data = await api.check_win(buy_id)
     print(f"Buy trade result: {buy_data['result']}\nBuy trade data: {buy_data}")
     sell_data = await api.check_win(sell_id)

--- a/examples/python/async/context.txt
+++ b/examples/python/async/context.txt
@@ -14,7 +14,7 @@ async def main(ssid: str):
     (buy_id, _) = await api.buy(asset="EURUSD_otc", amount=1.0, time=15, check_win=False)
     (sell_id, _) = await api.sell(asset="EURUSD_otc", amount=1.0, time=300, check_win=False)
     print(buy_id, sell_id)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     buy_data = await api.check_win(buy_id)
     print(f"Buy trade result: {buy_data['result']}\nBuy trade data: {buy_data}")
     sell_data = await api.check_win(sell_id)
@@ -191,7 +191,7 @@ async def main(ssid: str):
     api = PocketOptionAsync(ssid)
     _ = await api.buy(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
     _ = await api.sell(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     opened_deals = await api.opened_deals()
     print(f"Opened deals: {opened_deals}\nNumber of opened deals: {len(opened_deals)} (should be at least 2)")
     await asyncio.sleep(62) # Wait for the trades to complete
@@ -217,7 +217,7 @@ async def main(ssid: str):
     api = PocketOptionAsync(ssid)
     _ = await api.buy(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
     _ = await api.sell(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     opened_deals = await api.opened_deals()
     print(f"Opened deals: {opened_deals}\nNumber of opened deals: {len(opened_deals)} (should be at least 2)")
     await asyncio.sleep(62) # Wait for the trades to complete
@@ -331,7 +331,7 @@ async def main(ssid: str):
     (buy_id, _) = await api.buy(asset="EURUSD_otc", amount=1.0, time=300, check_win=False)
     (sell_id, _) = await api.sell(asset="EURUSD_otc", amount=1.0, time=300, check_win=False)
     print(buy_id, sell_id)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     buy_data = await api.check_win(buy_id)
     sell_data = await api.check_win(sell_id)
     print(f"Buy trade result: {buy_data['result']}\nBuy trade data: {buy_data}")

--- a/examples/python/sync/check_win.py
+++ b/examples/python/sync/check_win.py
@@ -12,7 +12,7 @@ def main(ssid: str):
     (sell_id, _) = api.sell(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
     print(buy_id, sell_id)
 
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     buy_data = api.check_win(buy_id)
     sell_data = api.check_win(sell_id)
     print(f"Buy trade result: {buy_data['result']}\nBuy trade data: {buy_data}")

--- a/examples/python/sync/get_open_and_close_trades.py
+++ b/examples/python/sync/get_open_and_close_trades.py
@@ -10,7 +10,7 @@ def main(ssid: str):
     time.sleep(5)  # Wait for connection to establish
     _ = api.buy(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
     _ = api.sell(asset="EURUSD_otc", amount=1.0, time=60, check_win=False)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     opened_deals = api.opened_deals()
     time.sleep(62)  # Wait for the trades to complete
     closed_deals = api.closed_deals()

--- a/examples/python/sync/logs.py
+++ b/examples/python/sync/logs.py
@@ -16,7 +16,7 @@ def main(ssid: str):
     (buy_id, _) = api.buy(asset="EURUSD_otc", amount=1.0, time=300, check_win=False)
     (sell_id, _) = api.sell(asset="EURUSD_otc", amount=1.0, time=300, check_win=False)
     print(buy_id, sell_id)
-    # This is the same as setting check_winwin to true on the api.buy and api.sell functions
+    # This is the same as setting check_win to true on the api.buy and api.sell functions
     buy_data = api.check_win(buy_id)
     sell_data = api.check_win(sell_id)
     print(f"Buy trade result: {buy_data['result']}\nBuy trade data: {buy_data}")

--- a/python/BinaryOptionsToolsV2/pocketoption/asynchronous.py
+++ b/python/BinaryOptionsToolsV2/pocketoption/asynchronous.py
@@ -522,7 +522,7 @@ class PocketOptionAsync:
         # Convert to hours for get_candles_live: offset * period seconds = total lookback seconds
         lookback_seconds = offset * period
         hours = max(0.1, lookback_seconds / 3600.0)
-        gen = self.get_candles_live(asset, period, hours=hours)
+        gen = self.get_candles_live(asset, period, hours=hours, max_rows=offset)
         closed, forming = await anext(gen)
         return closed
 

--- a/python/BinaryOptionsToolsV2/pocketoption/synchronous.py
+++ b/python/BinaryOptionsToolsV2/pocketoption/synchronous.py
@@ -312,7 +312,7 @@ class PocketOption:
         # offset = number of periods back, period = candle timeframe in seconds
         lookback_seconds = offset * period
         hours = max(0.1, lookback_seconds / 3600.0)
-        iterator = self.get_candles_live(asset, period, hours=hours)
+        iterator = self.get_candles_live(asset, period, hours=hours, max_rows=offset)
         closed, forming = next(iterator)
         return closed
 

--- a/python/README.md
+++ b/python/README.md
@@ -87,7 +87,7 @@ Key Features of PocketOptionAsync
  - **Market Data**:
    - `get_candles_live()`: Streams real-time gap-free candles (closed and currently forming) with historical backfill.
    - `candles()` / `get_candles()`: (Deprecated) Fetches historical candles (delegates to `get_candles_live`).
-   - `history()`: Retrieves recent data for a specific asset (delegates to `candles()`).
+   - `history()`: Retrieves recent historical data for a specific asset through the dedicated history endpoint.
    - `compile_candles()`: Compiles custom-period candlesticks from base tick data using strict UTC boundaries.
 - **Account Management**:
   - `balance()`: Returns the current account balance.
@@ -161,7 +161,7 @@ Key Features of PocketOption
  - **Market Data**:
    - `get_candles_live()`: Streams real-time gap-free candles (closed and currently forming) with historical backfill.
    - `candles()` / `get_candles()`: (Deprecated) Fetches historical candles (delegates to `get_candles_live`).
-   - `history()`: Retrieves recent data for a specific asset (delegates to `candles()`).
+   - `history()`: Retrieves recent historical data for a specific asset through the dedicated history endpoint.
    - `compile_candles()`: Compiles custom-period candlesticks from base tick data using strict UTC boundaries.
 - **Account Management**:
   - `balance()`: Retrieves account balance.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,6 +37,7 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-timeout",
+    "python-dotenv",
 ]
 [project.urls]
 Homepage = "https://chipatrade.gitlab.io/chipadevorg/BinaryOptionsTools-v2/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest>=7.0.0
 pytest-asyncio>=0.21.0
 pytest-timeout>=2.1.0
 anyio>=4.0.0
-
+python-dotenv>=1.0.0
 # Documentation dependencies
 mkdocs-material>=9.5.0
 pymdown-extensions>=10.7.0

--- a/test_examples.py
+++ b/test_examples.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from dotenv import load_dotenv
 
-def test_example(filepath: Path, ssid: str) -> bool:
+def run_example(filepath: Path, ssid: str) -> bool:
     print(f"\n==================================================")
     print(f"Testing Example: {filepath.relative_to(Path.cwd())}")
     print(f"==================================================")
@@ -53,14 +53,13 @@ def test_example(filepath: Path, ssid: str) -> bool:
     # 4. If it has a syntax or import error, it's a failure.
     if timed_out:
         print(f"Process timed out (10s) as expected for streaming examples.")
-        # Check if it succeeded in connecting and starting to stream
         success_markers = ["Connected: True", "Candle", "Balance", "Yield", "Found", "Log message", "WS Incoming"]
         if any(marker in stdout for marker in success_markers):
             print("Status: SUCCESS (Timed out after successful stream start)")
             return True
         else:
-            print("Status: WARNING (Timed out but no success markers found)")
-            return True # Streaming loops timing out is generally expected, but warning printed
+            print("Status: FAILURE (Timed out with no success markers)")
+            return False
     else:
         # Exited before 10s
         rc = proc.returncode
@@ -68,33 +67,36 @@ def test_example(filepath: Path, ssid: str) -> bool:
             print(f"Status: SUCCESS (Exited cleanly with code 0)")
             return True
         else:
-            # Check for python crash (SyntaxError, ImportError, AttributeError, NameError, etc.)
-            python_errors = ["Traceback", "SyntaxError", "ImportError", "AttributeError", "NameError", "TypeError", "ValueError"]
-            has_python_crash = any(err in stderr for err in python_errors)
-            
-            # Rejection due to invalid credentials is not a code failure
-            is_auth_rejection = "Login failed" in stdout or "invalid ssid" in stderr.lower() or "not set" in stdout.lower() or "not set" in stderr.lower()
-            
-            if has_python_crash and not is_auth_rejection:
-                print(f"Status: FAILURE (Exited with code {rc} and Python traceback/crash)")
-                return False
-            else:
-                print(f"Status: SUCCESS (Exited with code {rc} due to auth/rejection/skipped prerequisites)")
+            # Treat every nonzero exit as failure unless it matches a narrowly recognized intentional skip condition
+            skip_conditions = [
+                "invalid ssid",
+                "not set",
+                "Login failed",
+                "missing prerequisites",
+            ]
+            is_skip = any(condition in stdout or condition in stderr for condition in skip_conditions)
+            if is_skip:
+                print(f"Status: SKIPPED (Exited with code {rc} due to known skip condition)")
                 return True
+            print(f"Status: FAILURE (Exited with code {rc})")
+            return False
 
 def main():
     # Load .env file
     env_path = Path(__file__).resolve().parent / ".env"
     if env_path.exists():
         load_dotenv(env_path)
-    
+
     ssid = os.getenv("POCKET_OPTION_SSID", "mock_ssid_for_import_checks")
 
+    # Require explicit opt-in to run order-placing examples
+    run_order_examples = os.getenv("RUN_ORDER_EXAMPLES", "0") == "1"
+
     examples_dir = Path(__file__).resolve().parent / "examples" / "python"
-    
+
     # Find all python files recursively in examples/python
     example_files = sorted(list(examples_dir.glob("**/*.py")))
-    
+
     # Exclude files that are not runnable examples (e.g. validator.py is helper/utility)
     runnable_files = []
     for f in example_files:
@@ -103,18 +105,32 @@ def main():
             continue
         runnable_files.append(f)
 
+    # Exclude order-placing examples by default unless explicitly opted in
+    order_keywords = ["trade.py", "create_raw_order.py", "buy", "sell"]
+    if not run_order_examples:
+        runnable_files = [
+            f for f in runnable_files
+            if not any(keyword in f.name.lower() for keyword in order_keywords)
+        ]
+
+    # Validate that the supplied SSID is demo-only before allowing order-placing examples
+    if run_order_examples:
+        if not ssid or "isDemo" not in ssid:
+            print("Refusing to run order-placing examples: POCKET_OPTION_SSID is not a demo credential.")
+            sys.exit(1)
+
     print(f"Found {len(runnable_files)} runnable python examples to test.")
-    
+
     success_count = 0
     failures = []
-    
+
     for f in runnable_files:
-        success = test_example(f, ssid)
+        success = run_example(f, ssid)
         if success:
             success_count += 1
         else:
             failures.append(str(f.relative_to(examples_dir)))
-            
+
     print(f"\n==================================================")
     print(f"Example Testing Summary")
     print(f"==================================================")

--- a/tests/python/pocketoption/test_demo_ssid.py
+++ b/tests/python/pocketoption/test_demo_ssid.py
@@ -89,12 +89,15 @@ class TestDemoConnection:
         from contextlib import aclosing
         generator = api.get_candles_live("EURUSD_otc", period=60, hours=1.0, max_rows=10)
         async with aclosing(generator) as stream:
-            async for closed, forming in stream:
-                assert isinstance(closed, list), "Expected list of closed candles"
-                assert len(closed) > 0, "Expected at least one closed candle"
-                assert forming is None or isinstance(forming, dict), "Expected forming candle to be dict or None"
-                print(f"  get_candles_live closed count: {len(closed)}, forming: {forming}")
-                break
+            try:
+                closed, forming = await asyncio.wait_for(stream.__anext__(), timeout=20)
+            except asyncio.TimeoutError:
+                pytest.fail("Timed out waiting for first get_candles_live item")
+                return
+            assert isinstance(closed, list), "Expected list of closed candles"
+            assert len(closed) > 0, "Expected at least one closed candle"
+            assert forming is None or isinstance(forming, dict), "Expected forming candle to be dict or None"
+            print(f"  get_candles_live closed count: {len(closed)}, forming: {forming}")
 
     @pytest.mark.asyncio
     async def test_compile_candles(self, api):


### PR DESCRIPTION
- Implemented tests for BalanceModule to verify parsing of messages with 451- and 42 prefixes.
- Added tests for DealsApiModule to ensure correct handling of deal updates in both 451- and 42 formats.
- Included assertions to check the state updates after message processing.

fixed coderabbit suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Candle retrieval now returns the requested number of closed candles for both asynchronous and synchronous APIs.
  - Live-candle tests now fail clearly when data is not received within the expected time.

- **Documentation**
  - Clarified that history requests use a dedicated history endpoint.
  - Reformatted real-time streaming documentation without changing usage guidance.
  - Corrected `check_win` references in Python examples.

- **Testing**
  - Improved example validation and made order-placement examples opt-in for safer test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->